### PR TITLE
feat: implement DTO pattern and MapStruct for Member domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
     </scm>
     <properties>
         <java.version>25</java.version>
+        <lombok.version>1.18.44</lombok.version>
+        <mapstruct.version>1.6.3</mapstruct.version>
     </properties>
     <dependencies>
         <dependency>
@@ -63,7 +65,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.44</version>
+            <version>${lombok.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
@@ -75,6 +77,11 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -82,6 +89,32 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/smart/gym/smartgym/controller/MemberController.java
+++ b/src/main/java/com/smart/gym/smartgym/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.smart.gym.smartgym.controller;
 
-import com.smart.gym.smartgym.model.Member;
+import com.smart.gym.smartgym.dto.MemberRequestDTO;
+import com.smart.gym.smartgym.dto.MemberResponseDTO;
 import com.smart.gym.smartgym.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,28 +19,28 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
-    public List<Member> getAllMembers() {
+    public List<MemberResponseDTO> getAllMembers() {
         return memberService.getMembers();
     }
 
     @GetMapping("/{dni}")
-    public Member getMemberByDni(@PathVariable String dni) {
+    public MemberResponseDTO getMemberByDni(@PathVariable String dni) {
         return memberService.getMemberByDni(dni);
     }
 
     @GetMapping("/active")
-    public List<Member> getActiveMembers() {
+    public List<MemberResponseDTO> getActiveMembers() {
         return memberService.getActiveMembers(true);
     }
 
     @GetMapping("/inactive")
-    public List<Member> getInactiveMembers() {
+    public List<MemberResponseDTO> getInactiveMembers() {
         return memberService.getActiveMembers(false);
     }
 
     @PostMapping
-    public ResponseEntity<Member> createMember(@Valid @RequestBody Member member) {
-        Member savedMember = memberService.saveMember(member);
+    public ResponseEntity<MemberResponseDTO> createMember(@Valid @RequestBody MemberRequestDTO requestDTO) {
+        MemberResponseDTO savedMember = memberService.saveMember(requestDTO);
         return new ResponseEntity<>(savedMember, HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/smart/gym/smartgym/dto/MemberRequestDTO.java
+++ b/src/main/java/com/smart/gym/smartgym/dto/MemberRequestDTO.java
@@ -1,0 +1,9 @@
+package com.smart.gym.smartgym.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberRequestDTO extends PersonRequestDTO {
+}

--- a/src/main/java/com/smart/gym/smartgym/dto/MemberResponseDTO.java
+++ b/src/main/java/com/smart/gym/smartgym/dto/MemberResponseDTO.java
@@ -1,0 +1,12 @@
+package com.smart.gym.smartgym.dto;
+
+import lombok.Data;
+
+@Data
+public class MemberResponseDTO {
+    private String dni;
+    private String name;
+    private String locality;
+    private boolean active;
+    private boolean premium;
+}

--- a/src/main/java/com/smart/gym/smartgym/dto/MonitorRequestDTO.java
+++ b/src/main/java/com/smart/gym/smartgym/dto/MonitorRequestDTO.java
@@ -1,0 +1,9 @@
+package com.smart.gym.smartgym.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MonitorRequestDTO extends PersonRequestDTO{
+}

--- a/src/main/java/com/smart/gym/smartgym/dto/PersonRequestDTO.java
+++ b/src/main/java/com/smart/gym/smartgym/dto/PersonRequestDTO.java
@@ -1,0 +1,43 @@
+package com.smart.gym.smartgym.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public abstract class PersonRequestDTO {
+
+    @NotBlank(message = "The DNI is required")
+    @Pattern(regexp = "^[0-9]{8}[TRWAGMYFPDXBNJZSQVHLCKE]$", message = "The DNI format is incorrect")
+    private String dni;
+
+    @NotBlank(message = "The name is required")
+    @Size(min = 3, max = 50, message = "The name has to contain between 3 and 50 characters")
+    private String name;
+
+    @NotNull(message = "The birthdate is required")
+    private LocalDate birthdate;
+
+    @NotBlank(message = "The address is required")
+    private String address;
+
+    @NotBlank(message = "The locality is required")
+    private String locality;
+
+    @NotBlank(message = "The province is required")
+    private String province;
+
+    @NotBlank(message = "The post code is required")
+    @Pattern(regexp = "^[0-9]{5}$", message = "The post code must be 5 digits")
+    private String postCode;
+
+    @NotBlank(message = "The phone number is required")
+    @Pattern(regexp = "^[0-9]{9}$", message = "The phone number must be 9 digits")
+    private String phoneNumber;
+}

--- a/src/main/java/com/smart/gym/smartgym/mapper/MemberMapper.java
+++ b/src/main/java/com/smart/gym/smartgym/mapper/MemberMapper.java
@@ -1,0 +1,18 @@
+package com.smart.gym.smartgym.mapper;
+
+import com.smart.gym.smartgym.dto.MemberRequestDTO;
+import com.smart.gym.smartgym.dto.MemberResponseDTO;
+import com.smart.gym.smartgym.model.Member;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+import java.util.List;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface MemberMapper {
+    MemberResponseDTO toDTO(Member member);
+
+    List<MemberResponseDTO> toDTOList(List<Member> members);
+
+    Member toEntity(MemberRequestDTO requestDTO);
+}

--- a/src/main/java/com/smart/gym/smartgym/model/Person.java
+++ b/src/main/java/com/smart/gym/smartgym/model/Person.java
@@ -1,10 +1,6 @@
 package com.smart.gym.smartgym.model;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,39 +20,27 @@ public abstract class Person {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotBlank(message = "The DNI is required")
-    @Pattern(regexp = "^[0-9]{8}[TRWAGMYFPDXBNJZSQVHLCKE]$", message = "The DNI format is incorrect")
     @Column(unique = true, nullable = false)
     private String dni;
 
-    @NotBlank(message = "The name is required")
-    @Size(min = 3, max = 50, message = "The name has to contain between 3 and 50 characters")
     @Column(nullable = false)
     private String name;
 
-    @NotNull(message = "The birthdate is required")
     @Column(nullable = false)
     private LocalDate birthdate;
 
-    @NotBlank(message = "The address is required")
     @Column(nullable = false)
     private String address;
 
-    @NotBlank(message = "The locality is required")
     @Column(nullable = false)
     private String locality;
 
-    @NotBlank(message = "The province is required")
     @Column(nullable = false)
     private String province;
 
-    @NotBlank(message = "The post code is required")
-    @Pattern(regexp = "^[0-9]{5}$", message = "The post code must be 5 digits")
     @Column(nullable = false)
     private String postCode;
 
-    @NotBlank(message = "The phone number is required")
-    @Pattern(regexp = "^[0-9]{9}$", message = "The phone number must be 9 digits")
     @Column(nullable = false)
     private String phoneNumber;
 

--- a/src/main/java/com/smart/gym/smartgym/service/MemberService.java
+++ b/src/main/java/com/smart/gym/smartgym/service/MemberService.java
@@ -1,28 +1,46 @@
 package com.smart.gym.smartgym.service;
 
+import com.smart.gym.smartgym.dto.MemberRequestDTO;
+import com.smart.gym.smartgym.dto.MemberResponseDTO;
+import com.smart.gym.smartgym.mapper.MemberMapper;
 import com.smart.gym.smartgym.model.Member;
 import com.smart.gym.smartgym.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final MemberMapper memberMapper;
 
-    public Member saveMember(Member member){
-        return memberRepository.save(member);
+    public MemberResponseDTO saveMember(MemberRequestDTO requestDTO){
+        Member newMember = memberMapper.toEntity(requestDTO);
+
+        newMember.setActive(true);
+        newMember.setPremium(false);
+        newMember.setFee(30.0);
+        newMember.setRegistrationDate(LocalDate.now());
+        newMember.setLastAccessDate(LocalDate.now());
+
+        Member savedMember = memberRepository.save(newMember);
+
+        return memberMapper.toDTO(savedMember);
     }
 
-    public List<Member> getMembers() {
-        return memberRepository.findAllByActivities();
+    public List<MemberResponseDTO> getMembers() {
+        List<Member> members = memberRepository.findAllByActivities();
+        return memberMapper.toDTOList(members);
     }
 
-    public List<Member> getActiveMembers(boolean isActive) {
-        return memberRepository.findMemberByActive(isActive);
+    public List<MemberResponseDTO> getActiveMembers(boolean isActive) {
+        List<Member> members = memberRepository.findMemberByActive(isActive);
+
+        return memberMapper.toDTOList(members);
     }
 
     @Transactional
@@ -30,7 +48,10 @@ public class MemberService {
         memberRepository.deleteMemberByDni(dni);
     }
 
-    public Member getMemberByDni(String dni) {
-        return memberRepository.findMemberByDni(dni).orElseThrow(() -> new IllegalArgumentException("No member found with DNI: " + dni));
+
+    public MemberResponseDTO getMemberByDni(String dni) {
+        Member member = memberRepository.findMemberByDni(dni).orElseThrow(() -> new IllegalArgumentException("No member found with DNI: " + dni));
+
+        return memberMapper.toDTO(member);
     }
 }


### PR DESCRIPTION
## What does this PR do?

This PR introduces the Data Transfer Object (DTO) pattern to the Member domain to ensure strict separation of concerns between the web layer and the database layer.

## Key Changes
* **MapStruct Integration:** Configured `pom.xml` to link Lombok and MapStruct for automated mapper generation.
* **DTO Inheritance:** Created an abstract `PersonRequestDTO` to hold shared fields (DNI, name, address) and Jakarta Validation rules, following the DRY principle.
* **Layer Security:** Created `MemberRequestDTO` to act as the strict entry point for the API.
  * Created `MemberResponseDTO` to safely return data without exposing internal database fields.
* **Service Refactor:** Updated `MemberService` to handle entity-to-DTO translation using `MemberMapper`.